### PR TITLE
Always do the ns(-exclude)-regex mapping to re-pattern

### DIFF
--- a/src/kaocha/plugin/cloverage.clj
+++ b/src/kaocha/plugin/cloverage.clj
@@ -108,10 +108,16 @@
                (assoc :src-ns-path (:cov-src-ns-path opts))
 
                (contains? opts :cov-ns-regex)
-               (assoc :ns-regex (map re-pattern (:cov-ns-regex opts)))
+               (assoc :ns-regex (:cov-ns-regex opts))
 
                (contains? opts :cov-ns-exclude-regex)
-               (update :ns-exclude-regex into (map re-pattern (:cov-ns-exclude-regex opts)))))))
+               (update :ns-exclude-regex into (:cov-ns-exclude-regex opts))
+
+                :always
+                (update :ns-regex (partial map re-pattern))
+
+                :always
+                (update :ns-exclude-regex (partial map re-pattern))))))
 
 (defn run-cloverage [opts]
   ;; Compatibility with future versions


### PR DESCRIPTION
If we only do it on the CLI opts, then we can't load edn configs with
these options.

Solves: https://github.com/lambdaisland/kaocha-cloverage/issues/1