### PR TITLE
fix tests.edn example to enable with keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ bin/kaocha --plugin cloverage
 ``` clojure
 ;; tests.edn
 #kaocha/v1
-{:plugins [kaocha.plugin/cloverage]}
+{:plugins [:kaocha.plugin/cloverage]}
 ```
 
 This plugin adds a large amount of command line options to Kaocha. Run `bin/kaocha --plugin cloverage --help` to see them.


### PR DESCRIPTION
Without the colon, running kaocha fails with
`No method in multimethod '-register' for dispatch value: kaocha.plugin/cloverage`