### PR TITLE
Update Cloverage to 1.1.1, add --cov-exclude-call option introduced in Cloverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Added
 
+- Allow passing excluded calls to Cloverage, see also [Cloverage#242](https://github.com/cloverage/cloverage/pull/242)
+
 ## Fixed
 
 ## Changed
+
+- Upgrade Cloverage to version 1.1.1
 
 # 0.0-22 (2018-12-10 / ee13a86)
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "test"]
  :deps  {org.clojure/clojure {:mvn/version "1.10.0"}
          lambdaisland/kaocha {:mvn/version "0.0-343"}
-         cloverage           {:mvn/version "1.0.13"}}
+         cloverage           {:mvn/version "1.1.1"}}
  :aliases
  {:dev
   {}

--- a/src/kaocha/plugin/cloverage.clj
+++ b/src/kaocha/plugin/cloverage.clj
@@ -1,6 +1,5 @@
 (ns kaocha.plugin.cloverage
-  (:require [clojure.string :as str]
-            [cloverage.coverage :as c]
+  (:require [cloverage.coverage :as c]
             [kaocha.api :as api]
             [kaocha.plugin :as plugin :refer [defplugin]]
             [kaocha.result :as result]
@@ -25,7 +24,8 @@
    :nop? false
    :src-ns-path []
    :ns-regex []
-   :ns-exclude-regex []})
+   :ns-exclude-regex []
+   :exclude-call []})
 
 (def cli-opts*
   [["--cov-output PATH" "Cloverage output directory."]
@@ -59,6 +59,9 @@
     :assoc-fn accumulate]
    ["--cov-src-ns-path PATH"
     "Path (string) to directory containing test namespaces (can be repeated). Defaults to test suite source paths."
+    :assoc-fn accumulate]
+   ["--cov-exclude-call NAME"
+    "Name of fn/macro whose call sites are not to be instrumented (can be repeated)."
     :assoc-fn accumulate]])
 
 (def cli-opts (map #(into [nil] %) cli-opts*))
@@ -107,17 +110,20 @@
                (contains? opts :cov-src-ns-path)
                (assoc :src-ns-path (:cov-src-ns-path opts))
 
+               (contains? opts :cov-exclude-call)
+               (assoc :exclude-call (:cov-exclude-call opts))
+
                (contains? opts :cov-ns-regex)
                (assoc :ns-regex (:cov-ns-regex opts))
 
                (contains? opts :cov-ns-exclude-regex)
                (update :ns-exclude-regex into (:cov-ns-exclude-regex opts))
 
-                :always
-                (update :ns-regex (partial map re-pattern))
+               :always
+               (update :ns-regex (partial map re-pattern))
 
-                :always
-                (update :ns-exclude-regex (partial map re-pattern))))))
+               :always
+               (update :ns-exclude-regex (partial map re-pattern))))))
 
 (defn run-cloverage [opts]
   ;; Compatibility with future versions

--- a/src/kaocha/plugin/cloverage.clj
+++ b/src/kaocha/plugin/cloverage.clj
@@ -111,7 +111,7 @@
                (assoc :src-ns-path (:cov-src-ns-path opts))
 
                (contains? opts :cov-exclude-call)
-               (assoc :exclude-call (:cov-exclude-call opts))
+               (update :exclude-call into (:cov-exclude-call opts))
 
                (contains? opts :cov-ns-regex)
                (assoc :ns-regex (:cov-ns-regex opts))

--- a/src/kaocha/plugin/cloverage.clj
+++ b/src/kaocha/plugin/cloverage.clj
@@ -111,7 +111,7 @@
                (assoc :src-ns-path (:cov-src-ns-path opts))
 
                (contains? opts :cov-exclude-call)
-               (update :exclude-call into (:cov-exclude-call opts))
+               (update :exclude-call into (map symbol (:cov-exclude-call opts)))
 
                (contains? opts :cov-ns-regex)
                (assoc :ns-regex (:cov-ns-regex opts))

--- a/test/unit/kaocha/plugin/cloverage_test.clj
+++ b/test/unit/kaocha/plugin/cloverage_test.clj
@@ -137,9 +137,9 @@
 
     (testing "--cov-exclude-call"
       (is (= [] (:exclude-call (update-config' {} []))))
-      (is (= ["my.ns/fn"] (:exclude-call (update-config' {:exclude-call ["my.ns/fn"]} []))))
-      (is (= ["my.other.ns/fn"] (:exclude-call (update-config' {} ["--cov-exclude-call" "my.other.ns/fn"]))))
-      (is (= ["my.ns/fn" "my.other.ns/fn"] (:exclude-call (update-config' {:exclude-call ["my.ns/fn"]} ["--cov-exclude-call" "my.other.ns/fn"])))))))
+      (is (= ['my.ns/fn] (:exclude-call (update-config' {:exclude-call ['my.ns/fn]} []))))
+      (is (= ['my.other.ns/fn] (:exclude-call (update-config' {} ["--cov-exclude-call" "my.other.ns/fn"]))))
+      (is (= ['my.ns/fn 'my.other.ns/fn] (:exclude-call (update-config' {:exclude-call ['my.ns/fn]} ["--cov-exclude-call" "my.other.ns/fn"])))))))
 
 (deftest run-cloverage-test
   (let [arglists (:arglists (meta #'cloverage.coverage/run-main))]

--- a/test/unit/kaocha/plugin/cloverage_test.clj
+++ b/test/unit/kaocha/plugin/cloverage_test.clj
@@ -133,7 +133,13 @@
     (testing "--cov-ns-exclude-regex"
       (is (= [] (:ns-exclude-regex (update-config' {} []))))
       (is (= ["foo.*"] (map re->str (:ns-exclude-regex (update-config' {:ns-exclude-regex ["foo.*"]} [])))))
-      (is (= ["foo" "bar"] (map re->str (:ns-exclude-regex (update-config' {:ns-exclude-regex ["foo"]} ["--cov-ns-exclude-regex" "bar"]))))))))
+      (is (= ["foo" "bar"] (map re->str (:ns-exclude-regex (update-config' {:ns-exclude-regex ["foo"]} ["--cov-ns-exclude-regex" "bar"]))))))
+
+    (testing "--cov-exclude-call"
+      (is (= [] (:exclude-call (update-config' {} []))))
+      (is (= ["my.ns/fn"] (:exclude-call (update-config' {:exclude-call ["my.ns/fn"]} []))))
+      (is (= ["my.other.ns/fn"] (:exclude-call (update-config' {} ["--cov-exclude-call" "my.other.ns/fn"]))))
+      (is (= ["my.ns/fn" "my.other.ns/fn"] (:exclude-call (update-config' {:exclude-call ["my.ns/fn"]} ["--cov-exclude-call" "my.other.ns/fn"])))))))
 
 (deftest run-cloverage-test
   (let [arglists (:arglists (meta #'cloverage.coverage/run-main))]


### PR DESCRIPTION
Hey there!

I upgraded the dependency on cloverage to version 1.1.1 and introduced a new option added in [cloverage#242](https://github.com/cloverage/cloverage/pull/242) to exclude certain high-form macros.

Thoughts?