### PR TITLE
Ensure data readers are initialized before running cloverage

### DIFF
--- a/src/kaocha/plugin/cloverage.clj
+++ b/src/kaocha/plugin/cloverage.clj
@@ -127,10 +127,18 @@
 
 (defn run-cloverage [opts]
   ;; Compatibility with future versions
-  (let [arity (count (first (:arglists (meta #'c/run-main))))]
-    (case arity
-      1 (c/run-main [opts])
-      2 (c/run-main [opts] {}))))
+  (let [arity (count (first (:arglists (meta #'c/run-main))))
+        decls      (-> []
+                       (.getClass)
+                       (.getClassLoader)
+                       (.getResources "data_readers.clj")
+                       enumeration-seq)
+        read-decls (comp read-string slurp)
+        readers    (reduce merge {} (map read-decls decls))]
+    (binding [clojure.tools.reader/*data-readers* readers]
+      (case arity
+        1 (c/run-main [opts])
+        2 (c/run-main [opts] {})))))
 
 (defplugin kaocha.plugin/cloverage
   (cli-options [opts]

--- a/src/kaocha/plugin/cloverage.clj
+++ b/src/kaocha/plugin/cloverage.clj
@@ -127,7 +127,7 @@
 
 (defn run-cloverage [opts]
   ;; Compatibility with future versions
-  (let [arity (count (first (:arglists (meta #'c/run-main))))
+  (let [arity      (count (first (:arglists (meta #'c/run-main))))
         decls      (-> []
                        (.getClass)
                        (.getClassLoader)


### PR DESCRIPTION
Similar to [what was already done for `lein-cloverage`](https://github.com/cloverage/cloverage/pull/255),
data readers need to be evaluated before before running cloverage otherwise
custom tagged literals will result in errors such as (using `honeysql`):

```
No reader function for tag sql/call.
```