### PR TITLE
switch back to upstream cloverage 1.1.3

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "test"]
  :deps  {org.clojure/clojure    {:mvn/version "1.10.1"}
          lambdaisland/kaocha    {:mvn/version "0.0-601"}
-         lambdaisland/cloverage {:mvn/version "1.1.2-no-aot"}}
+         cloverage              {:mvn/version "1.1.3"}}
  :aliases
  {:dev
   {}

--- a/src/kaocha/plugin/cloverage.clj
+++ b/src/kaocha/plugin/cloverage.clj
@@ -1,5 +1,5 @@
 (ns kaocha.plugin.cloverage
-  (:require [lambdaisland.cloverage.coverage :as c]
+  (:require [cloverage.coverage :as c]
             [kaocha.api :as api]
             [kaocha.plugin :as plugin :refer [defplugin]]
             [kaocha.result :as result]


### PR DESCRIPTION
a new version is out that doesn't aot compile clojure.tools.reader anymore:
https://github.com/cloverage/cloverage/blob/master/CHANGELOG.md#113