### PR TITLE
switch back to upstream cloverage 1.1.3 (this time with working tests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Unreleased
 
-## Added
-
-## Fixed
-
 ## Changed
+
+- Switch back to vanilla Cloverage, and bump it to 1.1.3. This version no longer
+  contains an aot-compiled tools.reader.
 
 # 1.0-45 (2020-03-29 / 8642129)
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "test"]
  :deps  {org.clojure/clojure    {:mvn/version "1.10.1"}
          lambdaisland/kaocha    {:mvn/version "0.0-601"}
-         lambdaisland/cloverage {:mvn/version "1.1.2-no-aot"}}
+         cloverage              {:mvn/version "1.1.3"}}
  :aliases
  {:dev
   {}

--- a/src/kaocha/plugin/cloverage.clj
+++ b/src/kaocha/plugin/cloverage.clj
@@ -1,5 +1,5 @@
 (ns kaocha.plugin.cloverage
-  (:require [lambdaisland.cloverage.coverage :as c]
+  (:require [cloverage.coverage :as c]
             [kaocha.api :as api]
             [kaocha.plugin :as plugin :refer [defplugin]]
             [kaocha.result :as result]

--- a/test/unit/kaocha/plugin/cloverage_test.clj
+++ b/test/unit/kaocha/plugin/cloverage_test.clj
@@ -143,24 +143,24 @@
       (is (= ['my.ns/fn 'my.other.ns/fn] (:exclude-call (update-config' {:exclude-call ['my.ns/fn]} ["--cov-exclude-call" "my.other.ns/fn"])))))))
 
 (deftest run-cloverage-test
-  (let [arglists (:arglists (meta #'lambdaisland.cloverage.coverage/run-main))]
+  (let [arglists (:arglists (meta #'cloverage.coverage/run-main))]
     (try
       (let [run-main (fn [a1] a1)]
-        (alter-meta! #'lambdaisland.cloverage.coverage/run-main assoc :arglists '([:a1]))
-        (with-redefs [lambdaisland.cloverage.coverage/run-main run-main]
+        (alter-meta! #'cloverage.coverage/run-main assoc :arglists '([:a1]))
+        (with-redefs [cloverage.coverage/run-main run-main]
           (is (= [:opts] (cov/run-cloverage :opts)))))
 
       (let [run-main (fn [a1 a2] [a1 a2])]
-        (alter-meta! #'lambdaisland.cloverage.coverage/run-main assoc :arglists '([:a1 :a2]))
-        (with-redefs [lambdaisland.cloverage.coverage/run-main run-main]
+        (alter-meta! #'cloverage.coverage/run-main assoc :arglists '([:a1 :a2]))
+        (with-redefs [cloverage.coverage/run-main run-main]
           (is (= [[:opts] {}] (cov/run-cloverage :opts)))))
 
       (testing "no matching clause"
-        (alter-meta! #'lambdaisland.cloverage.coverage/run-main assoc :arglists '([:a1 :a2 :a3]))
+        (alter-meta! #'cloverage.coverage/run-main assoc :arglists '([:a1 :a2 :a3]))
         (is (thrown? java.lang.IllegalArgumentException (cov/run-cloverage :opts))))
 
       (finally
-        (alter-meta! #'lambdaisland.cloverage.coverage/run-main assoc :arglists arglists)))))
+        (alter-meta! #'cloverage.coverage/run-main assoc :arglists arglists)))))
 
 (deftest cloverage-plugin-test
   (let [chain (plugin/load-all [:kaocha.plugin/cloverage])]
@@ -180,8 +180,8 @@
                                                            :kaocha.result/fail 2}]})
                   ;; unfortunately we can't invoke Cloverage "for real", or it
                   ;; will really mess up our coverage results
-                  lambdaisland.cloverage.coverage/run-main (fn [[opts] & _]
-                                                ((lambdaisland.cloverage.coverage/runner-fn {:runner :kaocha}) opts))]
+                  cloverage.coverage/run-main (fn [[opts] & _]
+                                                ((cloverage.coverage/runner-fn {:runner :kaocha}) opts))]
 
       (is (thrown+? :kaocha/early-exit
                     (plugin/run-hook* chain :kaocha.hooks/main {:cloverage/opts {:src-ns-path ["src"]}})))


### PR DESCRIPTION
i cherry-picked the changelog entry and updated the namespace references in the tests file.  
otherwise this is the same as #8 