### PR TITLE
Update cloverage version to fix instrumentation

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src"]
  :deps  {org.clojure/clojure {:mvn/version "1.10.1"}
          lambdaisland/kaocha {:mvn/version "0.0-601"}
-         cloverage/cloverage {:mvn/version "1.2.0"}}
+         cloverage/cloverage {:mvn/version "1.2.4"}}
  :aliases
  {:dev
   {}


### PR DESCRIPTION
Ran into the following issue earlier with apache's FileUtils.

https://github.com/cloverage/cloverage/issues/309

Seems like it was fixed in 1.2.1, while 1.2.4 is the latest.

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
